### PR TITLE
Make sure the fake schedule is a tibble

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflseedR
 Title: Functions to Efficiently Simulate and Evaluate NFL Seasons
-Version: 1.2.0
+Version: 1.2.0.9000
 Authors@R: c(
     person("Lee", "Sharpe", role = c("aut", "cph")),
     person("Sebastian", "Carl", , "mrcaseb@gmail.com", role = c("cre", "aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# nflseedR (development version)
+
+* Fixed error in `simulate_nfl()` where it crashes because the "fake schedule" isn't a tibble. (#43)
+
 # nflseedR 1.2.0
 
 * `simulate_nfl()` gained the new argument `sim_include` to allow more access to what is actually being simulated. This makes it possible skip playoff simulation or the (possibly heavy) computation of draft order. (#34)

--- a/R/simulate_nfl.R
+++ b/R/simulate_nfl.R
@@ -285,7 +285,7 @@ simulate_nfl <- function(nfl_season = NULL,
       ".csv?raw=true"
     )
     tryCatch({
-      schedule <- data.table::fread(fn)
+      schedule <- data.table::fread(fn) %>% tibble::as_tibble()
       cli::cli_alert_info("No actual schedule exists for {.val {nfl_season}}, using fake schedule with correct opponents.")
     }, error = function(cond) {
       cli::cli_abort("Unable to locate a schedule for {.val {nfl_season}}")


### PR DESCRIPTION
Fixes this error 
``` r
s <- nflseedR::simulate_nfl(2024, simulations = 2)
#> ℹ 17:21:34 | Loading games data
#> ℹ No actual schedule exists for 2024, using fake schedule with correct opponents.
#> ℹ 17:21:36 | Beginning simulation of 2 seasons in 1 round
#> Error:
#> ℹ In index: 1.
#> Caused by error in `simulate_week()`:
#> ! During Week 1, your `process_games()` function had the following issues: `games` was not a tibble.
```

<sup>Created on 2024-01-19 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>