### PR TITLE
set width of logo columns in summary method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflseedR
 Title: Functions to Efficiently Simulate and Evaluate NFL Seasons
-Version: 1.2.0.9000
+Version: 1.2.0.9001
 Authors@R: c(
     person("Lee", "Sharpe", role = c("aut", "cph")),
     person("Sebastian", "Carl", , "mrcaseb@gmail.com", role = c("cre", "aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # nflseedR (development version)
 
 * Fixed error in `simulate_nfl()` where it crashes because the "fake schedule" isn't a tibble. (#43)
+* The `summary` method `summary.nflseedR_simulation()` explicitly sets the columns width of the logo column because those columns are hidden in some unclear scenarios.
 
 # nflseedR 1.2.0
 

--- a/R/summary_nflseedR.R
+++ b/R/summary_nflseedR.R
@@ -131,7 +131,8 @@ summary.nflseedR_simulation <- function(object, ...){
       gt::ends_with("won_conf") ~ gt::px(60),
       gt::ends_with("won_sb") ~   gt::px(60),
       gt::ends_with("draft1") ~   gt::px(60),
-      gt::ends_with("draft5") ~   gt::px(60)
+      gt::ends_with("draft5") ~   gt::px(60),
+      gt::ends_with("team") ~     gt::px(60)
     ) %>%
     gt::cols_align(
       align = "right",


### PR DESCRIPTION
because the logos are hidden when knitting to html. 

I don't know why this happens. The logos are actually there but the columns are too narrow to render them. It's very weird. Probably some problem with gt and knitr.